### PR TITLE
Add interactive quad canvas animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Quad Canvas Magic</title>
+<style>
+body,html{margin:0;height:100%;overflow:hidden}
+#grid{display:grid;grid-template-columns:repeat(2,50%);grid-template-rows:repeat(2,50%);width:100%;height:100%}
+canvas{width:100%;height:100%;display:block}
+</style>
+</head>
+<body>
+<div id="grid">
+  <canvas id="c1"></canvas>
+  <canvas id="c2"></canvas>
+  <canvas id="c3"></canvas>
+  <canvas id="c4"></canvas>
+</div>
+<script>
+// 🔧 Helpers
+const TAU=Math.PI*2;
+const rand=n=>Math.random()*n;
+
+// 🚀 Init canvases
+function init(){
+  document.querySelectorAll('canvas').forEach(c=>{
+    c.width=c.clientWidth;
+    c.height=c.clientHeight;
+  });
+  requestAnimationFrame(render);
+}
+
+// 🌈 Rainbow Spiral Galaxy
+function drawShape1(ctx,t){
+  ctx.save();
+  const cx=ctx.canvas.width/2,cy=ctx.canvas.height/2;
+  ctx.translate(cx,cy);
+  ctx.rotate(t*0.0002);
+  for(let i=0;i<500;i++){
+    const a=0.1*i,tau=a*TAU; // angle grows logarithmically
+    const r=2*i;
+    const x=r*Math.cos(tau),y=r*Math.sin(tau);
+    ctx.fillStyle=`hsl(${i%360},80%,60%)`;
+    ctx.fillRect(x,y,2,2);
+  }
+  ctx.restore();
+}
+
+// ⭐ Candy-Twist Star Prism
+function drawShape2(ctx,t){
+  const cw=ctx.canvas.width,ch=ctx.canvas.height;
+  ctx.clearRect(0,0,cw,ch);
+  ctx.save();
+  ctx.translate(cw/2,ch/2);
+  const scale=1+0.1*Math.sin(t*0.002);
+  ctx.scale(scale,scale);
+  const pts=10,R=Math.min(cw,ch)*0.4,r=R*0.5;
+  ctx.beginPath();
+  for(let i=0;i<=pts;i++){
+    const a=i*(TAU/pts)/2;
+    const radius=i%2?R:r;
+    ctx.lineTo(Math.cos(a)*radius,Math.sin(a)*radius);
+  }
+  const g=ctx.createLinearGradient(-R,-R,R,R);
+  g.addColorStop(0,'#ff99cc');
+  g.addColorStop(1,'#ffcc66');
+  ctx.fillStyle=g;
+  ctx.fill();
+  ctx.restore();
+}
+
+// 🫧 Bubble Mandala
+function drawShape3(ctx,t){
+  ctx.clearRect(0,0,ctx.canvas.width,ctx.canvas.height);
+  const cx=ctx.canvas.width/2,cy=ctx.canvas.height/2;
+  const maxR=Math.min(cx,cy);
+  for(let k=0;k<6;k++){
+    const progress=((t*0.0005+k/6)%1);
+    const radius=maxR*progress;
+    const count=8+k*2;
+    for(let i=0;i<count;i++){
+      const a=i*(TAU/count);
+      ctx.fillStyle=`hsla(${rand(360)},80%,80%,0.4)`;
+      ctx.beginPath();
+      ctx.arc(cx+radius*Math.cos(a),cy+radius*Math.sin(a),20,0,TAU);
+      ctx.fill();
+    }
+  }
+}
+
+// 🌳 Fractal Tree Fireworks
+function drawShape4(ctx,t){
+  ctx.clearRect(0,0,ctx.canvas.width,ctx.canvas.height);
+  ctx.strokeStyle='hsl('+((t/10)%360)+',100%,60%)';
+  ctx.lineWidth=2;
+  function branch(x,y,len,ang,depth){
+    if(depth===0) return;
+    const x2=x+len*Math.cos(ang),y2=y+len*Math.sin(ang);
+    ctx.beginPath();ctx.moveTo(x,y);ctx.lineTo(x2,y2);ctx.stroke();
+    const jitter=0.2;
+    branch(x2,y2,len*0.7,ang+jitter+rand(0.4),depth-1);
+    branch(x2,y2,len*0.7,ang-jitter-rand(0.4),depth-1);
+  }
+  branch(ctx.canvas.width/2,ctx.canvas.height,ctx.canvas.height/4,-Math.PI/2,6);
+}
+
+function render(time){
+  const c1=document.getElementById('c1');
+  const c2=document.getElementById('c2');
+  const c3=document.getElementById('c3');
+  const c4=document.getElementById('c4');
+  const ctx1=c1.getContext('2d');
+  const ctx2=c2.getContext('2d');
+  const ctx3=c3.getContext('2d');
+  const ctx4=c4.getContext('2d');
+  ctx1.clearRect(0,0,c1.width,c1.height);
+  drawShape1(ctx1,time);
+  drawShape2(ctx2,time);
+  drawShape3(ctx3,time);
+  drawShape4(ctx4,time);
+  requestAnimationFrame(render);
+}
+window.onload=init;
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` to display four canvases in a grid
- implement Rainbow Spiral Galaxy, Candy-Twist Star Prism, Bubble Mandala, and Fractal Tree Fireworks animations

## Testing
- `npx --yes serve index.html` *(fails: Not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543929f6a8832381286119585ae789